### PR TITLE
add support for area instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains IDEs (Rider, IDEA)
+.idea/

--- a/HuntHelper/Gui/HuntTrainUI.cs
+++ b/HuntHelper/Gui/HuntTrainUI.cs
@@ -558,7 +558,7 @@ public class HuntTrainUI : IDisposable
     private string GetAttributeFromMob(HuntTrainMobAttribute attribute, HuntTrainMob mob) =>
         attribute switch
         {
-            HuntTrainMobAttribute.Name => mob.Name,
+            HuntTrainMobAttribute.Name => $"{mob.Name}{mob.Instance.GetInstanceGlyph()}",
             HuntTrainMobAttribute.LastSeen => $"{(DateTime.Now.ToUniversalTime() - mob.LastSeenUTC).TotalMinutes:0.}m",
             HuntTrainMobAttribute.Position => $"({mob.Position.X:0.0}, {mob.Position.Y:0.0})"
         };

--- a/HuntHelper/Managers/Hunts/HuntManager.cs
+++ b/HuntHelper/Managers/Hunts/HuntManager.cs
@@ -122,16 +122,16 @@ public class HuntManager
         return _currentMobs;
     }
 
-    public void AddToTrain(BattleNpc mob, uint territoryid, uint mapid, string mapName, float zoneMapCoordSize)
+    public void AddToTrain(BattleNpc mob, uint territoryid, uint mapid, uint instance, string mapName, float zoneMapCoordSize)
     {
         //if mob already exists, update last seen - even if not recording
-        if (_trainManager.UpdateLastSeen(mob)) return;
+        if (_trainManager.UpdateLastSeen(mob, instance)) return;
         if (!_trainManager.RecordTrain) return;
         //only record A ranks
 #if !DEBUG //record all ranks while debugging coz weird ppl still kill ARR A ranks which makes it hard to find hunts to test with.
         if (GetHuntRank(mob.NameId) != HuntRank.A) return;
 #endif
-        _trainManager.AddMob(mob, territoryid, mapid, mapName, zoneMapCoordSize);
+        _trainManager.AddMob(mob, territoryid, mapid, instance, mapName, zoneMapCoordSize);
     }
 
     //bit much, grew big because I don't plan

--- a/HuntHelper/Managers/Hunts/Models/HuntTrainMob.cs
+++ b/HuntHelper/Managers/Hunts/Models/HuntTrainMob.cs
@@ -18,9 +18,10 @@ public class HuntTrainMob
 
     public uint TerritoryID { get; init; }
     public uint MapID { get; init; }
+    public uint Instance { get; init; }
 
     [JsonConstructor]
-    public HuntTrainMob(string name, uint mobId, uint territoryId, uint mapId, string mapName, Vector2 position, DateTime lastSeenUTC, bool dead = false)
+    public HuntTrainMob(string name, uint mobId, uint territoryId, uint mapId, uint instance, string mapName, Vector2 position, DateTime lastSeenUTC, bool dead = false)
     {
         Name = name;
         MobID = mobId;
@@ -30,6 +31,7 @@ public class HuntTrainMob
         Dead = dead;
         TerritoryID = territoryId;
         MapID = mapId;
+        Instance = instance;
 
         //PluginLog.Information($"Trying to make maplink with :|{mapName}|");  //"Mor Dhona" fails when using as placename
         MapLink = SeString.CreateMapLink(territoryId, mapId, position.X, position.Y)!;
@@ -51,5 +53,10 @@ public class HuntTrainMob
     public void MarkDead()
     {
         Dead = true;
+    }
+
+    public bool IsSameAs(uint mobID, uint instance)
+    {
+        return MobID == mobID && Instance == instance;
     }
 }

--- a/HuntHelper/Managers/Hunts/TrainManager.cs
+++ b/HuntHelper/Managers/Hunts/TrainManager.cs
@@ -41,19 +41,19 @@ public class TrainManager
         LoadHuntTrainRecord();
     }
 
-    public void AddMob(BattleNpc mob, uint territoryid, uint mapid, string mapName, float zoneMapCoordSize)
+    public void AddMob(BattleNpc mob, uint territoryid, uint mapid, uint instance, string mapName, float zoneMapCoordSize)
     {   //if already exists in train, return
-        if (HuntTrain.Any(m => m.MobID == mob.NameId)) return;
+        if (HuntTrain.Any(m => m.IsSameAs(mob.NameId, instance))) return;
         var position = new Vector2(MapHelpers.ConvertToMapCoordinate(mob.Position.X, zoneMapCoordSize),
             MapHelpers.ConvertToMapCoordinate(mob.Position.Z, zoneMapCoordSize));
-        var trainMob = new HuntTrainMob(mob.Name.TextValue, mob.NameId, territoryid, mapid, mapName, position, DateTime.UtcNow, false);
+        var trainMob = new HuntTrainMob(mob.Name.TextValue, mob.NameId, territoryid, mapid, instance, mapName, position, DateTime.UtcNow, false);
         HuntTrain.Add(trainMob);
     }
 
 
-    public bool UpdateLastSeen(BattleNpc mob)
+    public bool UpdateLastSeen(BattleNpc mob, uint instance)
     {
-        var existing = HuntTrain.FirstOrDefault(m => m.MobID == mob.NameId);
+        var existing = HuntTrain.FirstOrDefault(m => m.IsSameAs(mob.NameId, instance));
         if (existing == null) return false;
         existing.LastSeenUTC = DateTime.UtcNow;
         return true;

--- a/HuntHelper/Utilities/LocalizationUtil.cs
+++ b/HuntHelper/Utilities/LocalizationUtil.cs
@@ -1,0 +1,12 @@
+﻿using Dalamud.Game.Text;
+
+namespace HuntHelper.Utilities;
+
+public static class LocalizationUtil
+{
+    public static string GetInstanceGlyph(this uint instance)
+    {
+        if (instance is < 1 or > 9) return "";
+        return (SeIconChar.Instance1 + (int)instance - 1).ToIconString();
+    }
+}


### PR DESCRIPTION
i am working on adding some functionality that needs support for instances, so implemented this first! i have no idea about best practices or how to judge repo style, so please give any feedback you want about that stuff! i want to try to stay in style with the repo as much as i can.

this change should capture the instance of mobs in the train recorder, and display the instance on the mobs' name, as well as the area name on the map UI. i wanted to add the instance to the echo'd map link, as well, but after discussion with the some folks in the dalamud discord, they recommended i just enhance the map link functionality directly in dalamud, so i opened [a PR](https://github.com/goatcorp/Dalamud/pull/1490) for dalamud, and can integrate that into hunt helper once it's released ^w^.